### PR TITLE
update ui to work with multi process

### DIFF
--- a/app/components/maps-create.js
+++ b/app/components/maps-create.js
@@ -52,7 +52,6 @@ export default Ember.Component.extend({
 
         return val;
       });
-
       this.get('onSubmit')(...args);
     }
   },

--- a/app/components/processes-list.js
+++ b/app/components/processes-list.js
@@ -20,12 +20,8 @@ export default Ember.Component.extend({
 
   actions: {
 
-    onClickMap(process, mapId) {
-      this.get('onClickMap')(process, mapId);
-    },
-
-    onClickViewMapSegments(process, mapId) {
-      this.get('onClickViewMapSegments')(process, mapId);
+    onClickViewProcessMaps(process) {
+      this.get('onClickViewProcessMaps')(process);
     },
 
     onLoadMore() {

--- a/app/components/segments-list.js
+++ b/app/components/segments-list.js
@@ -20,8 +20,8 @@ export default Ember.Component.extend({
 
   actions: {
 
-    onClickSegment(linkHash) {
-      this.get('onClickSegment')(linkHash);
+    onClickSegment(process, linkHash) {
+      this.get('onClickSegment')(process, linkHash);
     },
 
     onLoadMore() {

--- a/app/controllers/map-explorer.js
+++ b/app/controllers/map-explorer.js
@@ -26,7 +26,7 @@ export default Base.extend({
 
     appendSegmentThenUpdate(...args) {
       return this.actions
-        .appendSegment.apply(this, args)
+        .appendSegment.apply(this, [...[this.get('model').processObject], ...args])
         .then(segment => {
           this.set('model.segments', [...this.get('model.segments'), segment]);
           this.set('showAppendSegmentDialog', false);

--- a/app/controllers/maps.js
+++ b/app/controllers/maps.js
@@ -24,7 +24,7 @@ export default Base.extend({
 
   limit: ENV.APP.ITEMS_PER_PAGE,
 
-  hasNoMore: Ember.computed('limit', 'model', function() {
+  hasNoMore: Ember.computed('limit', 'model', function () {
     return this.get('model').maps.length < this.get('limit');
   }),
 
@@ -44,9 +44,9 @@ export default Base.extend({
 
     createMapThenViewSegment(...args) {
       this.actions
-        .createMap.apply(this, args)
-        .then(segment => this.actions.viewSegment.call(this, segment.meta.linkHash))
-        .catch(() => {});
+        .createMap.apply(this, [this.get('model').processObject, args])
+        .then(segment => this.actions.viewSegment.call(this, this.get('model').processObject, segment.meta.linkHash))
+        .catch(() => { });
     }
 
   }

--- a/app/controllers/processes-index.js
+++ b/app/controllers/processes-index.js
@@ -1,0 +1,54 @@
+/*
+  Copyright 2017 Stratumn SAS. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import Base from 'agent-ui/controllers/base';
+import ENV from 'agent-ui/config/environment';
+
+export default Base.extend({
+
+  actions: {
+
+    transitionToProcess(process) {
+      this.transitionToRoute('process', { processObject: process, process: process.name });
+    },
+
+    transitionToProcessMaps(process) {
+      process
+        .getMapIds()
+        .then(maps => this.transitionToRoute('maps', { maps, processObject: process, process: process.name }));
+    },
+
+    transitionToProcessSegments(process) {
+      let mapIds;
+      process.getMapIds()
+        .then(maps => {
+          mapIds = maps;
+          return process.findSegments({ mapIds: maps });
+        })
+        .then(segments => this.transitionToRoute('segments', {
+          mapIds,
+          segments,
+          processObject: process,
+          process: process.name,
+          tags: '',
+          prevLinkHash: '',
+          limit: ENV.APP.ITEMS_PER_PAGE
+        }));
+    },
+
+  }
+
+});

--- a/app/controllers/processes.js
+++ b/app/controllers/processes.js
@@ -15,23 +15,27 @@
 */
 
 import Ember from 'ember';
+import Base from 'agent-ui/controllers/base';
+import ENV from 'agent-ui/config/environment';
 
-export default Ember.Component.extend({
+export default Base.extend({
+
+  queryParams: ['limit'],
+
+  limit: ENV.APP.ITEMS_PER_PAGE,
+
+  hasNoMore: Ember.computed('limit', 'model', function() {
+    return this.get('model').processes.length < this.get('limit');
+  }),
 
   actions: {
 
-    onClickMap(process, mapId) {
-      this.get('onClickMap')(process, mapId);
-    },
-
-    onClickViewMapSegments(process, mapId) {
-      this.get('onClickViewMapSegments')(process, mapId);
-    },
-
-    onLoadMore() {
-      this.get('onLoadMore')();
-    }
-
+    loadMore() {
+      if (!this.get('hasNoMore')) {
+        this.transitionToRoute({
+          queryParams: { limit: this.get('limit') + ENV.APP.ITEMS_PER_PAGE }
+        });
+      }
+    },  
   }
-
 });

--- a/app/controllers/segment.js
+++ b/app/controllers/segment.js
@@ -30,7 +30,7 @@ export default Base.extend({
 
     appendSegmentThenViewNext(...args) {
       this.actions
-        .appendSegment.apply(this, args)
+        .appendSegment.apply(this, [...[this.get('model').processObject], ...args])
         .then(segment => {
           this.transitionToRoute('segment', segment.meta.linkHash);
         })

--- a/app/helpers/eq.js
+++ b/app/helpers/eq.js
@@ -16,22 +16,5 @@
 
 import Ember from 'ember';
 
-export default Ember.Component.extend({
-
-  actions: {
-
-    onClickMap(process, mapId) {
-      this.get('onClickMap')(process, mapId);
-    },
-
-    onClickViewMapSegments(process, mapId) {
-      this.get('onClickViewMapSegments')(process, mapId);
-    },
-
-    onLoadMore() {
-      this.get('onLoadMore')();
-    }
-
-  }
-
-});
+const eq = (params) => params[0] === params[1];
+export default Ember.Helper.helper(eq);

--- a/app/router.js
+++ b/app/router.js
@@ -23,10 +23,12 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
-  this.route('maps');
-  this.route('map-explorer', { path: '/maps/:mapId' });
-  this.route('segments');
-  this.route('segment', { path: '/segments/:linkHash' });
+  this.route('processes');
+  this.route('process', {path: '/:process'});
+  this.route('maps', {path: '/:process/maps'});
+  this.route('map-explorer', { path: '/:process/maps/:mapId' });
+  this.route('segments', {path: '/:process/segments'});
+  this.route('segment', { path: '/:process/segments/:linkHash' });
   this.route('404', { path: '*path' });
   this.route('license');
 });

--- a/app/routes/404.js
+++ b/app/routes/404.js
@@ -18,9 +18,15 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
 
+  stratumn: Ember.inject.service('stratumn'),
+
   renderTemplate() {
     this._super();
     this.render('404-toolbar', { into: 'application', outlet: 'toolbar' });
+    this.get('stratumn').getAgent()
+      .then(agent =>
+        this.render('processes-index', { into: 'application', outlet: 'sidenav', model: agent })
+      );
   }
 
 });

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -27,6 +27,10 @@ export default Ember.Route.extend({
   renderTemplate() {
     this._super();
     this.render('index-toolbar', { into: 'application', outlet: 'toolbar' });
+    this.get('stratumn').getAgent()
+      .then(agent =>
+        this.render('processes-index', { into: 'application', outlet: 'sidenav', model: agent })
+      );
   }
 
 });

--- a/app/routes/license.js
+++ b/app/routes/license.js
@@ -18,9 +18,15 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
 
+  stratumn: Ember.inject.service('stratumn'),
+
   renderTemplate() {
     this._super();
     this.render('license-toolbar', { into: 'application', outlet: 'toolbar' });
+    this.get('stratumn').getAgent()
+      .then(agent =>
+        this.render('processes-index', { into: 'application', outlet: 'sidenav', model: agent })
+      );
   }
 
 });

--- a/app/routes/process.js
+++ b/app/routes/process.js
@@ -21,22 +21,17 @@ export default Ember.Route.extend({
   stratumn: Ember.inject.service('stratumn'),
 
   model(params) {
-    let appendActions;
-    let process;
     return this
       .get('stratumn')
       .getAgent()
-      .then(agent => {
-        process = agent.processes.find(p => p.name === params.process);
-        appendActions = process.actions.slice(1);
-        return process.findSegments(Object.assign({ limit: -1 }, params));
-      })
-      .then(segments => ({ mapId: params.mapId, segments, appendActions, process: params.process, processObject: process }));
+      .then(agent =>
+        ({ processObject: agent.processes.find(p => p.name === params.process) })
+      );
   },
 
   renderTemplate(ctrl, model) {
     this._super();
-    this.render('map-explorer-toolbar', { into: 'application', outlet: 'toolbar' });
+    this.render('process-toolbar', { into: 'application', outlet: 'toolbar' });
     this.get('stratumn').getAgent()
       .then(agent =>
         this.render('processes-index', {
@@ -44,14 +39,9 @@ export default Ember.Route.extend({
           outlet: 'sidenav',
           model: {
             processes: agent.processes,
-            currentProcess: model.process
+            currentProcess: model.processObject.name
           }
         }));
-  },
-
-  resetController(controller) {
-    controller.set('showAppendSegmentDialog', false);
-    controller.set('error');
   }
 
 });

--- a/app/routes/processes.js
+++ b/app/routes/processes.js
@@ -23,39 +23,25 @@ export default Ember.Route.extend({
 
   queryParams: { limit: { refreshModel: true } },
 
-  model(params) {
-    let process;
+  model() {
     return this
       .get('stratumn')
       .getAgent()
-      .then(agent => {
-        process = agent.processes.find(p => p.name === params.process);
-        return process.getMapIds(params);
-      })
-      .then(maps => {
-        return { processObject: process, maps };
-      });
+      .then(agent => ({ processes: agent.processes }));
   },
 
-  renderTemplate(ctrl, model) {
+  renderTemplate() {
     this._super();
-    this.render('maps-toolbar', { into: 'application', outlet: 'toolbar' });
+    this.render('processes-toolbar', { into: 'application', outlet: 'toolbar' });
     this.get('stratumn').getAgent()
       .then(agent =>
-        this.render('processes-index', {
-          into: 'application',
-          outlet: 'sidenav',
-          model: {
-            processes: agent.processes,
-            currentProcess: model.processObject.name
-          }
-        }));
+        this.render('processes-index', { into: 'application', outlet: 'sidenav', model: agent })
+      );
   },
 
   resetController(controller, isExiting) {
     if (isExiting) {
       controller.set('limit', ENV.APP.ITEMS_PER_PAGE);
-      controller.set('showCreateMapDialog', false);
       controller.set('error');
     }
   }

--- a/app/services/stratumn.js
+++ b/app/services/stratumn.js
@@ -19,29 +19,36 @@ import Ember from 'ember';
 import ENV from 'agent-ui/config/environment';
 
 function augmentAgent(agent) {
-  agent.actions = Object
-    .keys(agent.agentInfo.actions)
-    .map(name => {
-      const args = agent.agentInfo.actions[name].args;
-      const signature = `${name}(${args.join(', ')})`;
+  agent.processes = Object.keys(agent.processes).reduce((acc, p) => {
+    const updatedProcesses = acc;
+    const process = agent.processes[p];
+    process.actions = Object
+      .keys(process.processInfo.actions)
+      .map(name => {
+        const args = process.processInfo.actions[name].args;
+        const signature = `${name}(${args.join(', ')})`;
 
-      return { name, args, signature };
-    })
-    .sort((a, b) => {
-      if (a.name === 'init') {
-        return -1;
-      }
+        return { name, args, signature };
+      })
+      .sort((a, b) => {
+        if (a.name === 'init') {
+          return -1;
+        }
 
-      if (b.name === 'init') {
-        return 1;
-      }
+        if (b.name === 'init') {
+          return 1;
+        }
 
-      return a.name.localeCompare(b.name);
-    });
+        return a.name.localeCompare(b.name);
+      });
+    updatedProcesses.push(process);
+    return updatedProcesses;
+  }, []);
 }
 
 export default Ember.Service.extend({
   agent: null,
+  processes: null,
 
   getAgent() {
     if (this.get('agent')) {

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -24,19 +24,17 @@
     {{#paper-content class="flex layout-column"}}
 
       {{#paper-toolbar class="logo"}}
+        {{#link-to "index"}}
         Indigo Agent UI
+        {{/link-to}}
       {{/paper-toolbar}}
 
       {{#paper-list class="flex layout-column"}}
-        {{#link-to "index"}}
-          {{#paper-item}}Agent info{{/paper-item}}
-        {{/link-to}}
-        {{#link-to "maps"}}
-          {{#paper-item}}Maps{{/paper-item}}
-        {{/link-to}}
-        {{#link-to "segments"}}
-          {{#paper-item}}Segments{{/paper-item}}
-        {{/link-to}}
+
+      {{#paper-content}}
+      {{outlet "sidenav"}}
+      {{/paper-content}}
+
         <span class="flex"></span>
         <a href="http://indigoframework.com" target="_blank">
           {{#paper-item}}Documentation{{/paper-item}}

--- a/app/templates/components/processes-list.hbs
+++ b/app/templates/components/processes-list.hbs
@@ -14,16 +14,16 @@
   limitations under the License.
 -->
 
-{{#if maps.length}}
+{{#if processes.length}}
   {{#paper-list}}
-    {{#each maps as |mapId|}}
-      {{#paper-item onClick=(action "onClickMap" process mapId)}}
+    {{#each processes as |process|}}
+      {{#paper-item onClick=(action "onClickViewProcessMaps" process)}}
         <p>
-          <samp class="hide show-md show-lg">{{mapId}}</samp>
-          <samp class="hide-gt-sm">{{short-hash mapId}}</samp>
+          <samp class="hide show-md show-lg">{{process.name}}</samp>
+          <samp class="hide-gt-sm">{{short-hash process.name}}</samp>
         </p>
-        {{#paper-button class="md-secondary" onClick=(action "onClickViewMapSegments" process mapId)}}
-          View segments
+        {{#paper-button class="md-secondary" onClick=(action "onClickViewProcessMaps" process)}}
+          View maps
         {{/paper-button}}
       {{/paper-item}}
       {{paper-divider}}
@@ -35,6 +35,6 @@
 {{else}}
   {{#paper-content class="md-padding"}}
     <h2>Nothing to see here</h2>
-    <p>You don't have any maps at this point. Create one to get started.</p>
+    <p>You don't have any processes at this point. Create one to get started.</p>
   {{/paper-content}}
 {{/if}}

--- a/app/templates/components/segment-details.hbs
+++ b/app/templates/components/segment-details.hbs
@@ -20,6 +20,9 @@
 <h2 class="m-t-1">Map ID</h2>
 <p><samp>{{segment.link.meta.mapId}}</samp></p>
 
+<h2 class="m-t-1">Process</h2>
+<p><samp>{{segment.link.meta.process}}</samp></p>
+
 <h2 class="m-t-1">State hash</h2>
 <p><samp>{{segment.link.meta.stateHash}}</samp></p>
 

--- a/app/templates/components/segments-list.hbs
+++ b/app/templates/components/segments-list.hbs
@@ -18,7 +18,7 @@
   {{#paper-list}}
     {{paper-divider}}
     {{#each segments as |segment|}}
-      {{#paper-item onClick=(action "onClickSegment" segment.meta.linkHash)}}
+      {{#paper-item onClick=(action "onClickSegment" process segment.meta.linkHash)}}
         <p>
           <samp class="hide show-lg">{{segment.meta.linkHash}}</samp>
           <samp class="hide-gt-md">{{short-hash segment.meta.linkHash}}</samp>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -15,102 +15,26 @@
 -->
 
 {{#paper-content class="md-padding"}}
-  <div class="index-content">
+<div class="index-content">
 
-    <p>
-      An agent executes the logic of your workflow.
-      An instance of a workflow is called a map.
-      It contains the different steps of the workflow, called segments.
-    </p>
+  <p>
+    An agent executes the logic of your processes. A process is defined by a set of actions that may be used in the workflow. An instance of a process is called a map. It contains the different steps
+    of the process, called segments.
+  </p>
 
-    {{paper-divider}}
+  {{paper-divider}}
 
-    <h2>Endpoint</h2>
-    <p><samp><a href="{{model.url}}" target="_blank">{{model.url}}</a></samp></p>
-    <p class="light">
-      <small>
+  <h2>Endpoint</h2>
+  <p><samp><a href="{{model.url}}" target="_blank">{{model.url}}</a></samp></p>
+  <p class="light">
+    <small>
         You can use this URL to connect to your agent, using the
         <a class="nav-link" href="https://github.com/stratumn/agent-client-js/tree/alpha" target="_blank">Stratumn Javascript Agent Client</a>
         for instance.
       </small>
-    </p>
+  </p>
 
-    {{paper-divider}}
+  {{paper-divider}} 
 
-    <h2>Actions</h2>
-    <ul>
-      {{#each model.actions as |action|}}
-      <li><samp>{{action.signature}}</samp></li>
-      {{/each}}
-    </ul>
-    <p class="light">
-      <small>
-        These are the procedures that define how segments are added to your maps.
-      </small>
-    </p>
-
-    {{paper-divider}}
-
-    <h2>Store</h2>
-    <p class="light">
-      <small>
-        A store is responsible for saving your data. There are different adapters available depending on your needs.
-      </small>
-    </p>
-
-    <h3>Store adapter name</h3>
-    <p><samp>{{model.storeInfo.adapter.name}}</samp></p>
-
-    {{#if model.storeInfo.adapter.version}}
-      <h3>Store adapter version</h3>
-      <p><samp>{{model.storeInfo.adapter.version}}</samp></p>
-    {{/if}}
-
-    {{#if model.storeInfo.adapter.commit}}
-      <h3>Store adapter commit</h3>
-      <p><samp>{{model.storeInfo.adapter.commit}}</samp></p>
-    {{/if}}
-
-    {{#if model.storeInfo.adapter.description}}
-      <h3>Store adapter description</h3>
-      <p><samp>{{model.storeInfo.adapter.description}}</samp></p>
-    {{/if}}
-
-    {{paper-divider}}
-
-    <h2>Fossilizer</h2>
-    <p class="light">
-      <small>
-        A fossilizer adds the steps of your workflow to a timeline, such as a Blockchain or a trusted timestamping authority.
-      </small>
-    </p>
-
-    {{#if model.fossilizerInfo}}
-      <h3>Fossilizer adapter name</h3>
-      <p><samp>{{model.fossilizerInfo.adapter.name}}</samp></p>
-
-      {{#if model.fossilizerInfo.adapter.version}}
-        <h3>Fossilizer adapter version</h3>
-        <p><samp>{{model.fossilizerInfo.adapter.version}}</samp></p>
-      {{/if}}
-
-      {{#if model.fossilizerInfo.adapter.commit}}
-        <h3>Fossilizer adapter commit</h3>
-        <p><samp>{{model.fossilizerInfo.adapter.commit}}</samp></p>
-      {{/if}}
-
-      {{#if model.fossilizerInfo.adapter.description}}
-        <h3>Fossilizer adapter description</h3>
-        <p><samp>{{model.fossilizerInfo.adapter.description}}</samp></p>
-      {{/if}}
-
-      {{#if model.fossilizerInfo.adapter.blockchain}}
-        <h3>Fossilizer adapter blockchain</h3>
-        <p><samp>{{model.fossilizerInfo.adapter.blockchain}}</samp></p>
-      {{/if}}
-    {{else}}
-      <p>Your agent is not connected to a fossilizer.</p>
-    {{/if}}
-
-  </div>
+</div>
 {{/paper-content}}

--- a/app/templates/map-explorer-toolbar.hbs
+++ b/app/templates/map-explorer-toolbar.hbs
@@ -15,10 +15,19 @@
 -->
 
 <h1>
-  <span class="hide show-gt-sm">
-    {{#link-to "maps"}}Maps{{/link-to}}
+  <span class="hide show-md show-lg">
+    {{#link-to "process" model.process}}
+    {{model.process}}
+    {{/link-to}}
     {{paper-icon icon="chevron-right"}}
   </span>
+
+  <span class="hide show-gt-sm">
+    {{#link-to "maps" model.process}}Maps{{/link-to}}
+    {{paper-icon icon="chevron-right"}}
+  </span>
+      
+  
   <span class="hide show-md show-lg">{{model.mapId}}</span>
   <span class="hide-gt-sm">{{short-hash model.mapId}}</span>
   <span class="flex" />

--- a/app/templates/map-explorer.hbs
+++ b/app/templates/map-explorer.hbs
@@ -17,6 +17,7 @@
 {{#if showAppendSegmentDialog}}
   {{segment-append
     segment=segment
+    process=processObject
     error=error
     appendActions=model.appendActions
     onClose=(action "toggleAppendSegmentDialog")
@@ -25,5 +26,5 @@
 {{/if}}
 
 {{#paper-content}}
-  {{map-explorer chainscript=model.segments onSelectSegment=(action (mut segment))}}
+ {{map-explorer chainscript=model.segments onSelectSegment=(action (mut segment))}}
 {{/paper-content}}

--- a/app/templates/maps-toolbar.hbs
+++ b/app/templates/maps-toolbar.hbs
@@ -14,7 +14,15 @@
   limitations under the License.
 -->
 
-<h1>Maps</h1>
+<h1>
+  <span class="hide show-gt-sm">
+    {{#link-to "process" model.processObject.name}}
+    {{model.processObject.name}}
+    {{/link-to}}
+    {{paper-icon icon="chevron-right"}}
+  </span>
+    Maps
+</h1>
 <span class="flex"></span>
 {{#paper-button onClick=(action "toggleCreateMapDialog")}}
   {{paper-icon "add" size=30}}

--- a/app/templates/maps.hbs
+++ b/app/templates/maps.hbs
@@ -16,7 +16,7 @@
 
 {{#if showCreateMapDialog}}
   {{maps-create
-  	action=model.agent.actions.[0]
+  	action=model.processObject.actions.[0]
   	error=error
   	onClose=(action "toggleCreateMapDialog")
   	onSubmit=(action "createMapThenViewSegment")
@@ -26,6 +26,7 @@
 {{#paper-content}}
   {{maps-list
   	maps=model.maps
+    process=model.processObject
   	hasNoMore=hasNoMore
   	onClickMap=(action "exploreMap")
   	onClickViewMapSegments=(action "viewMapSegments")

--- a/app/templates/process-toolbar.hbs
+++ b/app/templates/process-toolbar.hbs
@@ -1,4 +1,4 @@
-/*
+<!--
   Copyright 2017 Stratumn SAS. All rights reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,26 +12,6 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-*/
+-->
 
-import Ember from 'ember';
-
-export default Ember.Component.extend({
-
-  actions: {
-
-    onClickMap(process, mapId) {
-      this.get('onClickMap')(process, mapId);
-    },
-
-    onClickViewMapSegments(process, mapId) {
-      this.get('onClickViewMapSegments')(process, mapId);
-    },
-
-    onLoadMore() {
-      this.get('onLoadMore')();
-    }
-
-  }
-
-});
+<h1>Process</h1>

--- a/app/templates/process.hbs
+++ b/app/templates/process.hbs
@@ -1,0 +1,80 @@
+<!--
+  Copyright 2017 Stratumn SAS. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+{{#paper-content class="md-padding"}}
+    <h1> {{model.processObject.name}} </h1>
+
+    {{!-- DESCRIBE THE ACTIONS OF A PROCESS --}}
+    <h3>Actions</h3>
+    <ul>
+      {{#each model.processObject.actions as |action|}}
+      <li><samp>{{action.signature}}</samp></li>
+      {{/each}}
+    </ul>
+    <p class="light">
+      <small>
+        These are the procedures that define how segments are added to your maps.
+      </small>
+    </p>
+
+    {{!-- DESCRIBE THE STORE INFOS OF A PROCESS --}}
+    <h3>Store</h3>
+    <p class="light">
+      <small>
+        A store is responsible for saving your data. There are different adapters available depending on your needs.
+      </small>
+    </p>
+    <h4>Store adapter name</h4>
+    <p><samp>{{model.processObject.storeInfo.adapter.name}}</samp></p>
+    {{#if model.processObject.storeInfo.adapter.version}}
+    <h4>Store adapter version</h4>
+    <p><samp>{{model.processObject.storeInfo.adapter.version}}</samp></p>
+    {{/if}} {{#if model.processObject.storeInfo.adapter.commit}}
+    <h4>Store adapter commit</h4>
+    <p><samp>{{model.processObject.storeInfo.adapter.commit}}</samp></p>
+    {{/if}} {{#if model.processObject.storeInfo.adapter.description}}
+    <h4>Store adapter description</h4>
+    <p><samp>{{model.processObject.storeInfo.adapter.description}}</samp></p>
+    {{/if}} {{paper-divider}}
+
+    {{!-- DESCRIBE THE FOSSILIZER INFOS OF A PROCESS --}}
+    <h3>Fossilizer</h3>
+    <p class="light">
+      <small>
+        A fossilizer adds the steps of your workflow to a timeline, such as a Blockchain or a trusted timestamping authority.
+      </small>
+    </p>
+    {{#if model.processObject.fossilizerInfo}}
+    <h4>Fossilizer adapter name</h4>
+    <p><samp>{{model.processObject.fossilizerInfo.adapter.name}}</samp></p>
+
+    {{#if model.processObject.fossilizerInfo.adapter.version}}
+    <h4>Fossilizer adapter version</h4>
+    <p><samp>{{model.processObject.fossilizerInfo.adapter.version}}</samp></p>
+    {{/if}} {{#if model.processObject.fossilizerInfo.adapter.commit}}
+    <h4>Fossilizer adapter commit</h4>
+    <p><samp>{{model.processObject.fossilizerInfo.adapter.commit}}</samp></p>
+    {{/if}} {{#if model.processObject.fossilizerInfo.adapter.description}}
+    <h4>Fossilizer adapter description</h4>
+    <p><samp>{{model.processObject.fossilizerInfo.adapter.description}}</samp></p>
+    {{/if}} {{#if model.processObject.fossilizerInfo.adapter.blockchain}}
+    <h4>Fossilizer adapter blockchain</h4>
+    <p><samp>{{model.processObject.fossilizerInfo.adapter.blockchain}}</samp></p>
+    {{/if}} {{else}}
+    <p>Your agent is not connected to a fossilizer.</p>
+    {{/if}}{{paper-divider}}
+
+{{/paper-content}}

--- a/app/templates/processes-index.hbs
+++ b/app/templates/processes-index.hbs
@@ -1,0 +1,34 @@
+<!--
+  Copyright 2017 Stratumn SAS. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+{{#each model.processes as |process|}}
+    {{#if (eq model.currentProcess process.name) }}      
+      {{#paper-item onClick=(action "transitionToProcess" process) }}
+          <b>{{process.name}}</b>
+      {{/paper-item}}
+      {{#paper-item onClick=(action "transitionToProcessMaps" process)}}
+          <li><samp><b>Maps</b></samp></li>
+      {{/paper-item}}
+      {{#paper-item onClick=(action "transitionToProcessSegments" process)}}
+          <li><samp><b>Segments</b></samp></li>
+      {{/paper-item}}
+
+    {{else}}
+      {{#paper-item onClick=(action "transitionToProcess" process) }}
+          {{process.name}}
+      {{/paper-item}}
+
+    {{/if}}
+{{/each}}

--- a/app/templates/processes-toolbar.hbs
+++ b/app/templates/processes-toolbar.hbs
@@ -1,4 +1,4 @@
-/*
+<!--
   Copyright 2017 Stratumn SAS. All rights reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,26 +12,6 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-*/
+-->
 
-import Ember from 'ember';
-
-export default Ember.Component.extend({
-
-  actions: {
-
-    onClickMap(process, mapId) {
-      this.get('onClickMap')(process, mapId);
-    },
-
-    onClickViewMapSegments(process, mapId) {
-      this.get('onClickViewMapSegments')(process, mapId);
-    },
-
-    onLoadMore() {
-      this.get('onLoadMore')();
-    }
-
-  }
-
-});
+<h1>Processes</h1>

--- a/app/templates/processes.hbs
+++ b/app/templates/processes.hbs
@@ -1,4 +1,4 @@
-/*
+<!--
   Copyright 2017 Stratumn SAS. All rights reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,26 +12,13 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-*/
+-->
 
-import Ember from 'ember';
-
-export default Ember.Component.extend({
-
-  actions: {
-
-    onClickMap(process, mapId) {
-      this.get('onClickMap')(process, mapId);
-    },
-
-    onClickViewMapSegments(process, mapId) {
-      this.get('onClickViewMapSegments')(process, mapId);
-    },
-
-    onLoadMore() {
-      this.get('onLoadMore')();
-    }
-
-  }
-
-});
+{{#paper-content}}
+  {{processes-list
+  	processes=model.processes
+  	hasNoMore=hasNoMore
+  	onClickViewProcessMaps=(action "viewProcessMaps")
+  	onLoadMore=(action "loadMore")
+  }}
+{{/paper-content}}

--- a/app/templates/segment-toolbar.hbs
+++ b/app/templates/segment-toolbar.hbs
@@ -16,7 +16,11 @@
 
 <h1>
   <span class="hide show-gt-sm">
-    {{#link-to "segments"}}Segments{{/link-to}}
+    {{#link-to "process" model.process}}{{model.process}}{{/link-to}}
+    {{paper-icon icon="chevron-right"}}
+  </span>
+  <span class="hide show-gt-sm">
+    {{#link-to "segments" model.process}}Segments{{/link-to}}
     {{paper-icon icon="chevron-right"}}
   </span>
   {{short-hash model.segment.meta.linkHash}}

--- a/app/templates/segments-toolbar.hbs
+++ b/app/templates/segments-toolbar.hbs
@@ -14,4 +14,12 @@
   limitations under the License.
 -->
 
-<h1>Segments</h1>
+<h1>
+  <span class="hide show-gt-sm">
+  {{#link-to "process" model.process}}
+  {{model.process}}
+  {{/link-to}}
+  {{paper-icon icon="chevron-right"}}
+  Segments
+  </span>
+</h1>

--- a/app/templates/segments.hbs
+++ b/app/templates/segments.hbs
@@ -25,6 +25,7 @@
   }}
   {{segments-list
   	segments=model.segments
+    process=model.processObject
   	hasNoMore=hasNoMore
     onClickSegment=(action "viewSegment")
   	onLoadMore=(action "loadMore")

--- a/tests/unit/helpers/eq-test.js
+++ b/tests/unit/helpers/eq-test.js
@@ -1,0 +1,21 @@
+
+import { eq } from 'agent-ui/helpers/eq';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | eq');
+
+// Replace this with your real tests.
+test('it returns true when passing equal values', function(assert) {
+  let result = eq([42, 42]);
+  assert.ok(result);
+});
+
+test('it works with strings', function(assert) {
+  let result = eq(["test", "test"]);
+  assert.ok(result);
+});
+
+test('it returns false otherwise', function(assert) {
+  let result = eq(["test", 42]);
+  assert.ok(result);
+});


### PR DESCRIPTION
Modified usage of the agent-client to work with its new version.
Updated homepage and moved all the processes' info to the process
page.
The process list has been added in the side-navigation component.
A dropdown is triggered when selecting a process to access directly
its maps and segments.
Breadcrumbs have been updated