### PR TITLE
fix error message cleanup in append modal 

### DIFF
--- a/app/components/maps-create.js
+++ b/app/components/maps-create.js
@@ -58,5 +58,9 @@ export default Ember.Component.extend({
 
   resetArgs() {
     this.set('args', this.get('action').args.map(name => ({ name })));
+  },
+
+  didDestroyElement() {
+    this.set("error", null)
   }
 });

--- a/app/components/segment-append.js
+++ b/app/components/segment-append.js
@@ -72,5 +72,10 @@ export default Ember.Component.extend({
   resetArgs() {
     const selectedAction = this.get('selectedAction');
     this.set('args', selectedAction.args.map(name => ({ name })));
+  },
+
+  didDestroyElement() {
+    this.set("error", null)
   }
+
 });

--- a/app/templates/components/segment-details.hbs
+++ b/app/templates/components/segment-details.hbs
@@ -35,4 +35,4 @@
 <p><samp>{{segment.action}}</samp></p>
 
 <h2 class="m-t-1">Raw JSON</h2>
-<pre><code class="json"></code></pre>
+<pre><code class="json">{{segment}}</code></pre>


### PR DESCRIPTION
Fixes #10
When an error occurred while appending a segment, an error message
was displayed at the top of the modal, but it didn't disappear when
closing and re-opening the modal.
